### PR TITLE
Fix price history parameters.

### DIFF
--- a/tdameritrade/priceHistory.go
+++ b/tdameritrade/priceHistory.go
@@ -8,12 +8,12 @@ import (
 )
 
 var (
-	validPeriodTypes = []string{"day", "month", "year", "ytd"}
+	validPeriodTypes    = []string{"day", "month", "year", "ytd"}
 	validFrequencyTypes = []string{"minute", "daily", "weekly", "monthly"}
 )
 
 const (
-	defaultPeriodType = "day"
+	defaultPeriodType    = "day"
 	defaultFrequencyType = "minute"
 )
 
@@ -27,19 +27,19 @@ type PriceHistoryService struct {
 
 // PriceHistoryOptions is parsed and translated to query options in the https request
 type PriceHistoryOptions struct {
-	PeriodType            string    `url:"periodType"`
-	Period                int       `url:"period"`
-	FrequencyType         string    `url:"frequencyType"`
-	Frequency             int       `url:"frequency"`
-	EndDate               time.Time `url:"endDate"`
-	StartDate             time.Time `url:"startDate"`
-	NeedExtendedHoursData *bool      `url:"needExtendedHoursData"`
+	PeriodType            string    `url:"periodType,omitempty"`
+	Period                int       `url:"period,omitempty"`
+	FrequencyType         string    `url:"frequencyType,omitempty"`
+	Frequency             int       `url:"frequency,omitempty"`
+	EndDate               time.Time `url:"endDate,omitempty"`
+	StartDate             time.Time `url:"startDate,omitempty"`
+	NeedExtendedHoursData *bool     `url:"needExtendedHoursData,omitempty"`
 }
 
 type PriceHistory struct {
 	Candles []struct {
 		Close    float64 `json:"close"`
-		Datetime int `json:"datetime"`
+		Datetime int     `json:"datetime"`
 		High     float64 `json:"high"`
 		Low      float64 `json:"low"`
 		Open     float64 `json:"open"`
@@ -108,4 +108,3 @@ func contains(s string, lst []string) bool {
 	}
 	return false
 }
-


### PR DESCRIPTION
Price history request breaks if PriceHistoryOptions struct is supplied, because optional values are also encoded as zero values.