### PR TITLE
Support/issue 27 remove anonymous sturcts

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -77,69 +77,70 @@ type OrderActivity struct {
 }
 
 type SecuritiesAccount struct {
-	Type                    string  `json:"type"`
-	AccountID               string  `json:"accountId"`
-	RoundTrips              float64 `json:"roundTrips"`
-	IsDayTrader             bool    `json:"isDayTrader"`
-	IsClosingOnlyRestricted bool    `json:"isClosingOnlyRestricted"`
-	Positions               []struct {
-		ShortQuantity                  float64    `json:"shortQuantity"`
-		AveragePrice                   float64    `json:"averagePrice"`
-		CurrentDayProfitLoss           float64    `json:"currentDayProfitLoss"`
-		CurrentDayProfitLossPercentage float64    `json:"currentDayProfitLossPercentage"`
-		LongQuantity                   float64    `json:"longQuantity"`
-		SettledLongQuantity            float64    `json:"settledLongQuantity"`
-		SettledShortQuantity           float64    `json:"settledShortQuantity"`
-		AgedQuantity                   float64    `json:"agedQuantity"`
-		Instrument                     Instrument `json:"instrument"`
-		MarketValue                    float64    `json:"marketValue"`
-	} `json:"positions"`
-	OrderStrategies []struct {
-		Session    string `json:"session"`
-		Duration   string `json:"duration"`
-		OrderType  string `json:"orderType"`
-		CancelTime struct {
-			Date        string `json:"date"`
-			ShortFormat bool   `json:"shortFormat"`
-		} `json:"cancelTime"`
-		ComplexOrderStrategyType string               `json:"complexOrderStrategyType"`
-		Quantity                 float64              `json:"quantity"`
-		FilledQuantity           float64              `json:"filledQuantity"`
-		RemainingQuantity        float64              `json:"remainingQuantity"`
-		RequestedDestination     string               `json:"requestedDestination"`
-		DestinationLinkName      string               `json:"destinationLinkName"`
-		ReleaseTime              string               `json:"releaseTime"`
-		StopPrice                float64              `json:"stopPrice"`
-		StopPriceLinkBasis       string               `json:"stopPriceLinkBasis"`
-		StopPriceLinkType        string               `json:"stopPriceLinkType"`
-		StopPriceOffset          float64              `json:"stopPriceOffset"`
-		StopType                 string               `json:"stopType"`
-		PriceLinkBasis           string               `json:"priceLinkBasis"`
-		PriceLinkType            string               `json:"priceLinkType"`
-		Price                    float64              `json:"price"`
-		TaxLotMethod             string               `json:"taxLotMethod"`
-		OrderLegCollection       []OrderLegCollection `json:"orderLegCollection"`
-		ActivationPrice          float64              `json:"activationPrice"`
-		SpecialInstruction       string               `json:"specialInstruction"`
-		OrderStrategyType        string               `json:"orderStrategyType"`
-		OrderID                  int64                `json:"orderId"`
-		Cancelable               bool                 `json:"cancelable"`
-		Editable                 bool                 `json:"editable"`
-		Status                   string               `json:"status"`
-		EnteredTime              string               `json:"enteredTime"`
-		CloseTime                string               `json:"closeTime"`
-		Tag                      string               `json:"tag"`
-		AccountID                int64                `json:"accountId"`
-		OrderActivityCollection  []OrderActivity      `json:"orderActivityCollection"`
-		ReplacingOrderCollection []struct {
-		} `json:"replacingOrderCollection"`
-		ChildOrderStrategies []struct {
-		} `json:"childOrderStrategies"`
-		StatusDescription string `json:"statusDescription"`
-	} `json:"orderStrategies"`
-	InitialBalances   Balance `json:"initialBalances"`
-	CurrentBalances   Balance `json:"currentBalances"`
-	ProjectedBalances Balance `json:"projectedBalances"`
+	Type                    string          `json:"type"`
+	AccountID               string          `json:"accountId"`
+	RoundTrips              float64         `json:"roundTrips"`
+	IsDayTrader             bool            `json:"isDayTrader"`
+	IsClosingOnlyRestricted bool            `json:"isClosingOnlyRestricted"`
+	Positions               []Position      `json:"positions"`
+	OrderStrategies         []OrderStrategy `json:"orderStrategies"`
+	InitialBalances         Balance         `json:"initialBalances"`
+	CurrentBalances         Balance         `json:"currentBalances"`
+	ProjectedBalances       Balance         `json:"projectedBalances"`
+}
+
+type Position struct {
+	ShortQuantity                  float64    `json:"shortQuantity"`
+	AveragePrice                   float64    `json:"averagePrice"`
+	CurrentDayProfitLoss           float64    `json:"currentDayProfitLoss"`
+	CurrentDayProfitLossPercentage float64    `json:"currentDayProfitLossPercentage"`
+	LongQuantity                   float64    `json:"longQuantity"`
+	SettledLongQuantity            float64    `json:"settledLongQuantity"`
+	SettledShortQuantity           float64    `json:"settledShortQuantity"`
+	AgedQuantity                   float64    `json:"agedQuantity"`
+	Instrument                     Instrument `json:"instrument"`
+	MarketValue                    float64    `json:"marketValue"`
+}
+
+type OrderStrategy struct {
+	Session                  string               `json:"session"`
+	Duration                 string               `json:"duration"`
+	OrderType                string               `json:"orderType"`
+	CancelTime               CancelTime           `json:"cancelTime"`
+	ComplexOrderStrategyType string               `json:"complexOrderStrategyType"`
+	Quantity                 float64              `json:"quantity"`
+	FilledQuantity           float64              `json:"filledQuantity"`
+	RemainingQuantity        float64              `json:"remainingQuantity"`
+	RequestedDestination     string               `json:"requestedDestination"`
+	DestinationLinkName      string               `json:"destinationLinkName"`
+	ReleaseTime              string               `json:"releaseTime"`
+	StopPrice                float64              `json:"stopPrice"`
+	StopPriceLinkBasis       string               `json:"stopPriceLinkBasis"`
+	StopPriceLinkType        string               `json:"stopPriceLinkType"`
+	StopPriceOffset          float64              `json:"stopPriceOffset"`
+	StopType                 string               `json:"stopType"`
+	PriceLinkBasis           string               `json:"priceLinkBasis"`
+	PriceLinkType            string               `json:"priceLinkType"`
+	Price                    float64              `json:"price"`
+	TaxLotMethod             string               `json:"taxLotMethod"`
+	OrderLegCollection       []OrderLegCollection `json:"orderLegCollection"`
+	ActivationPrice          float64              `json:"activationPrice"`
+	SpecialInstruction       string               `json:"specialInstruction"`
+	OrderStrategyType        string               `json:"orderStrategyType"`
+	OrderID                  int64                `json:"orderId"`
+	Cancelable               bool                 `json:"cancelable"`
+	Editable                 bool                 `json:"editable"`
+	Status                   string               `json:"status"`
+	EnteredTime              string               `json:"enteredTime"`
+	CloseTime                string               `json:"closeTime"`
+	Tag                      string               `json:"tag"`
+	AccountID                int64                `json:"accountId"`
+	OrderActivityCollection  []OrderActivity      `json:"orderActivityCollection"`
+	ReplacingOrderCollection []struct {
+	} `json:"replacingOrderCollection"`
+	ChildOrderStrategies []struct {
+	} `json:"childOrderStrategies"`
+	StatusDescription string `json:"statusDescription"`
 }
 
 type Balance struct {

--- a/hours.go
+++ b/hours.go
@@ -39,7 +39,7 @@ type Hours struct {
 }
 
 func (s *MarketHoursService) GetMarketHoursMulti(ctx context.Context, markets string, date time.Time) (*MarketHours, *Response, error) {
-	u := fmt.Sprintf("marketdata/hours")
+	u := "marketdata/hours"
 	if markets == "" {
 		return nil, nil, fmt.Errorf("no markets present")
 	}

--- a/instruments.go
+++ b/instruments.go
@@ -44,7 +44,7 @@ func (s *InstrumentService) GetInstrument(ctx context.Context, cusip string) (*I
 }
 
 func (s *InstrumentService) SearchInstruments(ctx context.Context, symbol, projection string) (*Instruments, *Response, error) {
-	u := fmt.Sprintf("instruments")
+	u := "instruments"
 	if symbol == "" {
 		return nil, nil, fmt.Errorf("no symbol present")
 	}

--- a/priceHistory.go
+++ b/priceHistory.go
@@ -38,16 +38,18 @@ type PriceHistoryOptions struct {
 }
 
 type PriceHistory struct {
-	Candles []struct {
-		Close    float64 `json:"close"`
-		Datetime int     `json:"datetime"`
-		High     float64 `json:"high"`
-		Low      float64 `json:"low"`
-		Open     float64 `json:"open"`
-		Volume   float64 `json:"volume"`
-	} `json:"candles"`
-	Empty  bool   `json:"empty"`
-	Symbol string `json:"symbol"`
+	Candles []Candle `json:"candles"`
+	Empty   bool     `json:"empty"`
+	Symbol  string   `json:"symbol"`
+}
+
+type Candle struct {
+	Close    float64 `json:"close"`
+	Datetime int     `json:"datetime"`
+	High     float64 `json:"high"`
+	Low      float64 `json:"low"`
+	Open     float64 `json:"open"`
+	Volume   float64 `json:"volume"`
 }
 
 // PriceHistory get the price history for a symbol

--- a/quotes.go
+++ b/quotes.go
@@ -66,9 +66,8 @@ type Quote struct {
 	Delayed                            bool    `json:"delayed"`
 }
 
-
 func (s *QuotesService) GetQuotes(ctx context.Context, symbols string) (*Quotes, *Response, error) {
-	u := fmt.Sprintf("marketdata/quotes")
+	u := "marketdata/quotes"
 	if symbols == "" {
 		return nil, nil, fmt.Errorf("no symbols present")
 	}
@@ -89,4 +88,3 @@ func (s *QuotesService) GetQuotes(ctx context.Context, symbols string) (*Quotes,
 
 	return quotes, resp, nil
 }
-


### PR DESCRIPTION
- resolves #27 
- resolves go-staticcheck warnings about unnecessary fmt usage

I did not replace the ReplacingOrderCollection and ChildOrderStrategies anonymous structs since they weren't documented well in the Ameritrade Docs.